### PR TITLE
[auto] release branch

### DIFF
--- a/VrInteractiveTracking.podspec
+++ b/VrInteractiveTracking.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |spec|
   spec.public_header_files = "VrInteractiveTracking/library/*.h"
   spec.library = "VrInteractiveDataV6"
 
-  spec.xcconfig  =  { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/VrInteractiveTracking/VrInteractiveTracking/Library"' }
+  spec.xcconfig  =  { 'LIBRARY_SEARCH_PATHS' => '$(PODS_ROOT)/VrInteractiveTracking/VrInteractiveTracking/Library' }
 end


### PR DESCRIPTION
Version 6.0.1

ライブラリのリンクエラーを解消

```
ld: in /Applications/Workspace/others/ssai-sample/ssai-sample/3rdParty/VrInteractiveTracking/VrInteractiveTracking/library/libVrInteractiveDataV6.a(VrInteractiveData.o), building for iOS, but linking in object file (/Applications/Workspace/others/ssai-sample/ssai-sample/3rdParty/VrInteractiveTracking/VrInteractiveTracking/library/libVrInteractiveDataV6.a(VrInteractiveData.o)) built for iOS Simulator, for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```